### PR TITLE
Update settings for disabling Prettier formatting on VSCode save

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,10 +67,12 @@ Paste in the follow to newly created `.eslintrc`:
       "source.fixAll.eslint": true
   },
   // Disable Prettier for JavaScript and React (but not for HTML, CSS or others in future)
-  "prettier.disableLanguages": [
-      "javascript",
-      "javascriptreact"
-  ],
+  "[javascriptreact]": {
+    "editor.formatOnSave": false
+  },
+  "[javascript]": {
+    "editor.formatOnSave": false
+  }
 ```
 
 **For other editors, you can add the following to your `package.json` and run it manually:**


### PR DESCRIPTION
This setting to disable prettier formatting (at least for [Esben Petersens's extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)) doesn't seem to work anymore.

![image](https://user-images.githubusercontent.com/560791/82125007-57513c00-9779-11ea-9e7e-05b1eab694b0.png)

I've been able to disable formatting with these new rules.