### PR TITLE
allow jsx in .tsx files

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = {
     'react/jsx-filename-extension': [
       1,
       {
-        extensions: ['.js', 'jsx']
+        extensions: ['.js', '.jsx', '.tsx']
       }
     ],
     // __ REACT


### PR DESCRIPTION
Thanks for this config! Found it very handy when setting up a NextJS project, but it currently warns when using JSX in typescript files:

```
$ yarn run eslint . --fix --ext js,jsx,ts,tsx

/my-app/pages/_app.tsx
  4:10  warning  JSX not allowed in files with extension '.tsx'  react/jsx-filename-extension

/my-app/pages/index.tsx
  6:5  warning  JSX not allowed in files with extension '.tsx'  react/jsx-filename-extension
  ```